### PR TITLE
Updated README and added OSTYPE check

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ upload to [github](https://github.com/vitessio/vitess/releases) rather than the
 docker images at
 [https://github.com/vitessio/vitess/tree/master/docker](https://github.com/vitessio/vitess/tree/master/docker).
 
-## Install Latest Vitess Release
+## Install Latest Vitess Release (Linux)
 
 The `install_latest.sh` script is a helper to install the latest release from
-[github](https://github.com/vitessio/vitess/releases):
+[github](https://github.com/vitessio/vitess/releases) on Linux:
 
 ```
 git clone https://github.com/planetscale/vitess-releases.git

--- a/bin/install_latest.sh
+++ b/bin/install_latest.sh
@@ -9,6 +9,11 @@
 # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 set -euo pipefail
 
+if [[ $OSTYPE != "linux-gnu" ]]; then
+    echo "Non-linux OS detected. Exiting."
+    exit 1
+fi
+
 INSTALL_DIR=${HOME}
 RELEASE_REPO_URL=https://api.github.com/repos/planetscale/vitess-releases/releases/latest
 LATEST_RELEASE_URL=$(curl -s ${RELEASE_REPO_URL} | grep "browser_download_url.*gz" | awk -F'"' '{print $4}')


### PR DESCRIPTION
sjmudd noted in the vitess #releases channel that `install_latest.sh` doesn't check that you're running linux. 

I've added a simple check and updated the README, though we still need to look into trimming down the release size, if possible. 