### PR TITLE
Update instructions

### DIFF
--- a/bin/release_README.md
+++ b/bin/release_README.md
@@ -1,16 +1,1 @@
-
-Running getting started tutorial:
-
-Assuming that you have MySQL and Java Runtime 8 installed (sudo apt-get install mysql-server-5.7 openjdk-8-jre):
-
-```
-export VTROOT=$(pwd)
-export VTTOP=$(pwd)
-export MYSQL_FLAVOR=MySQL56
-export VTDATAROOT=${HOME}/vtdataroot
-export PATH=${VTROOT}/bin:${PATH}
-sudo service apparmor stop; sudo service apparmor teardown; sudo update-rc.d -f apparmor remove
-cd examples/local
-```
-
-Now you can go here https://vitess.io/docs/tutorials/local and follow the intructions from "Starting a single keyspace cluster" section.
+Follow the binary install instructions from https://vitess.io/docs/get-started/local/


### PR DESCRIPTION
I think keeping this file up to date will be hard. We should just link to the website. The current problems:
- openjdk is no longer required because examples use etcd
- MYSQL_FLAVOR is no required
- I plan to eliminate VTTOP soon.
- The apparmor steps should also just disable the mysql profile.