### PR TITLE
fix cron bug, run every tuesday

### DIFF
--- a/.github/workflows/release_scheduled.yml
+++ b/.github/workflows/release_scheduled.yml
@@ -1,10 +1,10 @@
 name: release_scheduled
 on:
   schedule:
-    # Runs on the 1st and 3rd Tuesday of the month, at 1500 UTC.
+    # Runs every Tuesday, at 1500 UTC.
     #
-    # See: https://crontab.guru/#0_15_1-7,15-21_*_2
-    - cron: '0 15 1-7,15-21 * 2'
+    # See: https://crontab.guru/#0_15_*_*_2
+    - cron: '0 15 * * 2'
 
 jobs:
   build:


### PR DESCRIPTION
Originally tried to get cron to run every other Tuesday, but looks like that's not really easy to do in cron. What was actually happening was it was creating releases every Tuesday AND on days-of-month 1-7 and 15-21 🤦. 

For now going to just say create releases every Tuesday.