### PR TITLE
include -R option with gh release create

### DIFF
--- a/build-vitess-packages.sh
+++ b/build-vitess-packages.sh
@@ -201,7 +201,7 @@ echo;echo
 
 if [ $DRY_RUN -eq 0 ]; then
   echo "Creating GitHub Release..."
-  gh release create -F /tmp/release-notes.txt -t "Vitess Release ${VERSION}-${SHORT_REV}" ${SHORT_REV}
+  gh release create -R planetscale/vitess-releases -F /tmp/release-notes.txt -t "Vitess Release ${VERSION}-${SHORT_REV}" ${SHORT_REV}
   for file in ${RELEASE_FILES}; do
     attempts=0
     while [ $attempts -lt 3 ]; do


### PR DESCRIPTION
GH cli [upgrade](https://github.com/cli/cli/releases/tag/v2.21.0) breaks current script:

![image](https://user-images.githubusercontent.com/340318/209699395-9d2697e9-6dc3-4e43-a9e1-877850be6fc0.png)

Think this should fix it.